### PR TITLE
Allow different parsing modes

### DIFF
--- a/src/main/scala/io/circe/fs2/ParsingPipe.scala
+++ b/src/main/scala/io/circe/fs2/ParsingPipe.scala
@@ -6,9 +6,11 @@ import io.circe.{ Json, ParsingFailure }
 import io.circe.jawn.CirceSupportParser
 
 private[fs2] abstract class ParsingPipe[F[_], S] extends Pipe[F, S, Json] {
+  protected[this] def parsingMode: AsyncParser.Mode
+  
   protected[this] def parseWith(parser: AsyncParser[Json])(in: S): Either[ParseException, Seq[Json]]
 
-  private[this] final def makeParser: AsyncParser[Json] = CirceSupportParser.async(mode = AsyncParser.UnwrapArray)
+  private[this] final def makeParser: AsyncParser[Json] = CirceSupportParser.async(mode = parsingMode)
 
   private[this] final def doneOrLoop[A](p: AsyncParser[Json])(h: Handle[F, S]): Pull[F, Json, Unit] =
     h.receive1 {

--- a/src/main/scala/io/circe/fs2/package.scala
+++ b/src/main/scala/io/circe/fs2/package.scala
@@ -6,17 +6,33 @@ import _root_.jawn.{ AsyncParser, ParseException }
 import io.circe.jawn.CirceSupportParser
 
 package object fs2 {
-  final def stringParser[F[_]]: Pipe[F, String, Json] = new ParsingPipe[F, String] {
+  final def stringArrayParser[F[_]]: Pipe[F, String, Json] = stringParser(AsyncParser.UnwrapArray)
+
+  final def stringStreamParser[F[_]]: Pipe[F, String, Json] = stringParser(AsyncParser.ValueStream)
+
+  final def byteArrayParser[F[_]]: Pipe[F, Byte, Json] = byteParser(AsyncParser.UnwrapArray)
+
+  final def byteStreamParser[F[_]]: Pipe[F, Byte, Json] = byteParser(AsyncParser.ValueStream)
+
+  final def byteArrayParserC[F[_]]: Pipe[F, Chunk[Byte], Json] = byteParserC(AsyncParser.UnwrapArray)
+
+  final def byteStreamParserC[F[_]]: Pipe[F, Chunk[Byte], Json] = byteParserC(AsyncParser.ValueStream)
+  
+  final def stringParser[F[_]](mode: AsyncParser.Mode): Pipe[F, String, Json] = new ParsingPipe[F, String] {
     protected[this] final def parseWith(p: AsyncParser[Json])(in: String): Either[ParseException, Seq[Json]] =
       p.absorb(in)(CirceSupportParser.facade)
+
+    protected[this] val parsingMode: AsyncParser.Mode = mode
   }
 
-  final def byteParserC[F[_]]: Pipe[F, Chunk[Byte], Json] = new ParsingPipe[F, Chunk[Byte]] {
+  final def byteParserC[F[_]](mode: AsyncParser.Mode): Pipe[F, Chunk[Byte], Json] = new ParsingPipe[F, Chunk[Byte]] {
     protected[this] final def parseWith(p: AsyncParser[Json])(in: Chunk[Byte]): Either[ParseException, Seq[Json]] =
       p.absorb(in.toArray)(CirceSupportParser.facade)
+
+    protected[this] val parsingMode: AsyncParser.Mode = mode
   }
 
-  final def byteParser[F[_]]: Pipe[F, Byte, Json] = _.through(pipe.chunks).through(byteParserC)
+  final def byteParser[F[_]](mode: AsyncParser.Mode): Pipe[F, Byte, Json] = _.through(pipe.chunks).through(byteParserC(mode))
 
   final def decoder[F[_], A](implicit decode: Decoder[A]): Pipe[F, Json, A] =
     _.flatMap { json =>


### PR DESCRIPTION
I was running into a parse failures when trying to parse a stream of json objects. 
```scala
val jsonStream = fs2.Stream.emit[Task, String]("""{"a": 1}""")
jsonStream.repeat.take(2).through(stringParser).run.unsafeRun()
```
would result in 
`> io.circe.ParsingFailure: expected eof got { (line 1, column 9)`

@travisbrown pointed me at https://github.com/circe/circe/pull/712
@BenFradet @n4to4 
