### PR TITLE
Update circe to 0.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val compilerOptions = Seq(
   "-Xfuture"
 )
 
-val circeVersion = "0.9.0"
+val circeVersion = "0.9.1"
 val fs2Version = "0.10.0-RC2"
 val previousCirceFs2Version = "0.8.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")


### PR DESCRIPTION
This doesn't really make a difference for non-Scala.js projects, but we might as well do it.