### PR TITLE
Bump circe to 0.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val compilerOptions = Seq(
 
 val circeVersion = "0.11.0"
 val fs2Version = "1.0.2"
-val previousCirceFs2Version = "0.9.0"
+val previousCirceFs2Version = "0.10.0"
 
 val baseSettings = Seq(
   scalacOptions ++= compilerOptions,

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val compilerOptions = Seq(
   "-Xfuture"
 )
 
-val circeVersion = "0.10.1"
+val circeVersion = "0.11.0"
 val fs2Version = "1.0.2"
 val previousCirceFs2Version = "0.9.0"
 

--- a/src/main/scala/io/circe/fs2/ParsingPipe.scala
+++ b/src/main/scala/io/circe/fs2/ParsingPipe.scala
@@ -1,9 +1,9 @@
 package io.circe.fs2
 
 import _root_.fs2.{ Chunk, Pipe, Pull, RaiseThrowable, Stream }
-import _root_.jawn.{ AsyncParser, ParseException }
 import io.circe.{ Json, ParsingFailure }
 import io.circe.jawn.CirceSupportParser
+import org.typelevel.jawn.{ AsyncParser, ParseException }
 
 private[fs2] abstract class ParsingPipe[F[_], S] extends Pipe[F, S, Json] {
   protected[this] val raiseThrowable: RaiseThrowable[F]

--- a/src/main/scala/io/circe/fs2/package.scala
+++ b/src/main/scala/io/circe/fs2/package.scala
@@ -1,8 +1,8 @@
 package io.circe
 
 import _root_.fs2.{Chunk, Pipe, RaiseThrowable, Stream}
-import _root_.jawn.{AsyncParser, ParseException}
 import io.circe.jawn.CirceSupportParser
+import org.typelevel.jawn.{AsyncParser, ParseException}
 
 package object fs2 {
   final def stringArrayParser[F[_] : RaiseThrowable]: Pipe[F, String, Json] = stringParser(AsyncParser.UnwrapArray)

--- a/src/test/scala/io/circe/fs2/Fs2Suite.scala
+++ b/src/test/scala/io/circe/fs2/Fs2Suite.scala
@@ -6,7 +6,7 @@ import io.circe.{ DecodingFailure, Json, ParsingFailure }
 import io.circe.fs2.examples._
 import io.circe.generic.auto._
 import io.circe.syntax._
-import jawn.AsyncParser
+import org.typelevel.jawn.AsyncParser
 import scala.collection.immutable.{Stream => StdStream}
 
 class Fs2Suite extends CirceSuite {

--- a/src/test/scala/io/circe/fs2/Fs2Suite.scala
+++ b/src/test/scala/io/circe/fs2/Fs2Suite.scala
@@ -2,7 +2,7 @@ package io.circe.fs2
 
 import _root_.fs2.{ Pipe, Stream, text }
 import cats.effect.IO
-import io.circe.{ DecodingFailure, Json, ParsingFailure }
+import io.circe.{ DecodingFailure, Json }
 import io.circe.fs2.examples._
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -87,30 +87,6 @@ class Fs2Suite extends CirceSuite {
         .compile.toVector.attempt.unsafeRunSync() === Right(foos.toVector))
     }
 
-  "stringArrayParser" should "return ParsingFailure" in {
-    testParsingFailure(_.through(stringArrayParser))
-  }
-
-  "stringStreamParser" should "return ParsingFailure" in {
-    testParsingFailure(_.through(stringStreamParser))
-  }
-
-  "byteArrayParser" should "return ParsingFailure" in {
-    testParsingFailure(_.through(text.utf8Encode).through(byteArrayParser))
-  }
-
-  "byteStreamParser" should "return ParsingFailure" in {
-    testParsingFailure(_.through(text.utf8Encode).through(byteStreamParser))
-  }
-
-  "byteArrayParserC" should "return ParsingFailure" in {
-    testParsingFailure(_.through(text.utf8Encode).chunks.through(byteArrayParserC))
-  }
-
-  "byteStreamParserC" should "return ParsingFailure" in {
-    testParsingFailure(_.through(text.utf8Encode).chunks.through(byteStreamParserC))
-  }
-
   "decoder" should "return DecodingFailure" in
     forAll { (fooStdStream: StdStream[Foo], fooVector: Vector[Foo]) =>
       sealed trait Foo2
@@ -132,15 +108,6 @@ class Fs2Suite extends CirceSuite {
 
       assert(
         stream.through(through).compile.toVector.attempt.unsafeRunSync() === Right(foos.toVector))
-    }
-  }
-
-  private def testParsingFailure(through: Pipe[IO, String, Json]) = {
-    forAll { (stringStdStream: StdStream[String], stringVector: Vector[String]) =>
-      val result = Stream("}").append(stringStream(stringStdStream, stringVector))
-        .through(through)
-        .compile.toVector.attempt.unsafeRunSync()
-      assert(result.isLeft && result.left.get.isInstanceOf[ParsingFailure])
     }
   }
 }


### PR DESCRIPTION
supersedes #46 

- [x] weird change of behavior:

```scala
scala> CirceSupportParser.async(AsyncParser.UnwrapArray)
res0: org.typelevel.jawn.AsyncParser[io.circe.Json] = org.typelevel.jawn.AsyncParser@3d718422

scala> .absorb("}")(CirceSupportParser.facade)
res1: Either[org.typelevel.jawn.ParseException,Seq[io.circe.Json]] = Right(ArrayBuffer())
```

Any ideas @travisbrown ?
- [x] previous circe version