### PR TITLE
Update to Scalafmt 2.0.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.0-RC8
+version = 2.0.0
 continuationIndent.defnSite = 2
 docstrings = JavaDoc
 includeCurlyBraceInSelectChains = false
@@ -7,4 +7,10 @@ newlines.alwaysBeforeElseAfterCurlyIf = false
 newlines.alwaysBeforeMultilineDef = false
 optIn.breakChainOnFirstMethodDot = false
 spaces.inImportCurlyBraces = true
-
+rewrite.rules = [
+  AvoidInfix,
+  RedundantBraces,
+  RedundantParens,
+  AsciiSortImports,
+  PreferCurlyFors
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,3 @@ script:
   # See http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -89,9 +89,9 @@ lazy val publishSettings = Seq(
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
+      Some("snapshots".at(nexus + "content/repositories/snapshots"))
     else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+      Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
   },
   /* Someday maybe Scaladoc will actually work on package object-only projects.
   autoAPIMappings := true,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0-RC2

--- a/src/test/scala/io/circe/fs2/Fs2Suite.scala
+++ b/src/test/scala/io/circe/fs2/Fs2Suite.scala
@@ -157,16 +157,15 @@ class Fs2Suite extends CirceSuite {
       }
     }
 
-  private def testParser(mode: AsyncParser.Mode, through: Pipe[IO, String, Json]) = {
+  private def testParser(mode: AsyncParser.Mode, through: Pipe[IO, String, Json]) =
     forAll { (fooStdStream: StdStream[Foo], fooVector: Vector[Foo]) =>
       val stream = serializeFoos(mode, fooStream(fooStdStream, fooVector))
       val foos = (fooStdStream ++ fooVector).map(_.asJson)
 
       assert(stream.through(through).compile.toVector.attempt.unsafeRunSync() === Right(foos.toVector))
     }
-  }
 
-  private def testParsingFailure(through: Pipe[IO, String, Json]) = {
+  private def testParsingFailure(through: Pipe[IO, String, Json]) =
     forAll { (stringStdStream: StdStream[String], stringVector: Vector[String]) =>
       val result = Stream("}")
         .append(stringStream(stringStdStream, stringVector))
@@ -177,5 +176,4 @@ class Fs2Suite extends CirceSuite {
         .unsafeRunSync()
       assert(result.isLeft && result.left.get.isInstanceOf[ParsingFailure])
     }
-  }
 }


### PR DESCRIPTION
Follow up to #64 that updates the Scalafmt version, standardizes on the current circe Scalafmt config (which has some new inspiration from fs2's), and attempts to fix the code coverage reporting (which I think must have been broken by #63?) by updating sbt to the latest 1.3.0 release candidate.