### PR TITLE
Update to fs2 3.0, cats-effect 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val compilerOptions = Seq(
 )
 
 val circeVersion = "0.13.0"
-val fs2Version = "2.5.4"
+val fs2Version = "3.0.1"
 val jawnVersion = "1.1.2"
 val previousCirceFs2Version = "0.11.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.8
+sbt.version=1.4.9

--- a/src/main/scala/io/circe/fs2/package.scala
+++ b/src/main/scala/io/circe/fs2/package.scala
@@ -1,9 +1,10 @@
 package io.circe
 
-import _root_.fs2.{ Chunk, Pipe, Stream }
+import _root_.fs2.{ Chunk, Pipe, RaiseThrowable, Stream }
 import cats.effect.Sync
 import io.circe.jawn.CirceSupportParser
 import org.typelevel.jawn.{ AsyncParser, ParseException }
+
 import scala.collection.Seq
 
 package object fs2 {
@@ -39,7 +40,7 @@ package object fs2 {
 
   final def byteParser[F[_]: Sync](mode: AsyncParser.Mode): Pipe[F, Byte, Json] = _.chunks.through(byteParserC(mode))
 
-  final def decoder[F[_]: Sync, A](implicit decode: Decoder[A]): Pipe[F, Json, A] =
+  final def decoder[F[_]: RaiseThrowable, A](implicit decode: Decoder[A]): Pipe[F, Json, A] =
     _.flatMap { json =>
       decode(json.hcursor) match {
         case Left(df) => Stream.raiseError(df)

--- a/src/test/scala/io/circe/fs2/Fs2Suite.scala
+++ b/src/test/scala/io/circe/fs2/Fs2Suite.scala
@@ -2,6 +2,7 @@ package io.circe.fs2
 
 import _root_.fs2.{ Pipe, Stream, text }
 import cats.effect.IO
+import cats.effect.unsafe.implicits._
 import io.circe.{ DecodingFailure, Json, ParsingFailure }
 import io.circe.fs2.examples._
 import io.circe.generic.auto._


### PR DESCRIPTION
Fixes #206 

There were no APIs with incompatible signatures (in explicit parts) used, so, I only patched Spec to revive `unsafeRunSync()`.

Additionally bumped `sbt`, because 1.4.8 causes issues at least on my machine.