### PR TITLE
docs: replace Segment with Chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ is:
 ```
 
 The appropriate pipe for the job also depends on your input stream value type (i.e. `String`, `Byte`
-or `Segment[Byte]`).
+or `Chunk[Byte]`).
 
 The following table sums up every pipe available as a function of the input stream value type as
 well as the JSON structure:
 
-|                |String              |Byte              |Segment[Byte]      |
+|                |String              |Byte              |Chunk[Byte]      |
 |----------------|--------------------|------------------|-------------------|
-|__Value stream__|`stringStreamParser`|`byteStreamParser`|`byteStreamParserS`|
-|__Array__       |`stringArrayParser` |`byteArrayParser` |`byteArrayParserS` |
+|__Value stream__|`stringStreamParser`|`byteStreamParser`|`byteStreamParserC`|
+|__Array__       |`stringArrayParser` |`byteArrayParser` |`byteArrayParserC` |
 
 As an example, let's say we have a stream of strings representing a JSON array, we'll
 pick the `stringArrayParser` pipe which converts a stream of `String` to a stream of `Json`, Circe's


### PR DESCRIPTION
the use of Segment was misleading because is no longer in the code, since this type is from an older version of fs2